### PR TITLE
Allow 'text/javascript; charset=UTF-8' as JSON valid format

### DIFF
--- a/src/Negotiation/FormatNegotiator.php
+++ b/src/Negotiation/FormatNegotiator.php
@@ -5,7 +5,7 @@ namespace Bangpound\oEmbed\Negotiation;
 class FormatNegotiator extends \Negotiation\FormatNegotiator
 {
     protected $formats = array(
-      'json' => array('application/json', 'application/x-json', 'application/json+oembed'),
+      'json' => array('application/json', 'application/x-json', 'application/json+oembed', 'text/javascript; charset=UTF-8'),
       'xml' => array('text/xml', 'application/xml', 'application/x-xml', 'text/xml+oembed'),
     );
 }


### PR DESCRIPTION
I'm trying to embed a facebook link using the library and I'm not able because FB oEmbed response is in formar 'text/javascript; charset=UTF-8' instead of 'application/json'
https://developers.facebook.com/docs/plugins/oembed-endpoints
Would be great if you could add this to allow to embed FB posts.

Thanks
